### PR TITLE
Make environment variables more visible

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ Workflow
 Singularity
 -----------
 
-See `singularity` this is likely recomended for workstation and single user installs.
+See [singularity](singularity) this is likely recomended for workstation and single user installs.
 
 Building archivetar
 -------------------
@@ -38,7 +38,7 @@ Archivetar does use setuptools so it can be installed by `pip` to add to your gl
 
 ### Configuration
 
-Archivetar uses environment for configuration
+Archivetar uses environment variables for configuration
 
 ```
 # Required
@@ -50,6 +50,12 @@ AT_SOURCE=<Globus UUID Default Collection>
 AT_DESTINATION=<Globus UUID Default Collection>
 AT_TAR_SIZE=<Default --tar-size>
 ```
+
+Singularity containers already have required variables defined inside the
+container (e.g. see `singularity exec archivetar_master.sif env | grep ^AT_`),
+so you would only need to [re]define the optional ones to suite your site's
+needs.
+
 
 #### Dev options
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -134,8 +134,25 @@ for them to finish.  This is ok in most cases but not ones where you want to
 know the transfer is complete before modifying / deleting data or scripting
 multiple archives. 
 
-The `--wait` option tells archivetar to wait for all globus transfer to finish.
-It will also print print globus performance information as it runs. 
+The `--wait` option tells archivetar to wait for all Globus transfer to finish.
+It will also print print Globus performance information as it runs. 
 
 The option `--rm-at-files`  implies `--wait` for tars _only_ and not transfers
 created by the `--size` option.
+
+
+Environment Variables
+---------------------
+
+Several `archivetar` settings can be controlled by environment variables (handy
+for overriding defaults or for site-specific customization, e.g. inside Lmod
+modules).  Currently supported environment variables:
+
+| Variable         | Equivalent CLI option                | Meaning                                          |
+|------------------|--------------------------------------|--------------------------------------------------|
+| `AT_TAR_SIZE`    | `-t TAR_SIZE`, `--tar-size TAR_SIZE` | Target tar size before options (eg. `10G`, `1T`) |
+| `AT_SOURCE`      | `--source SOURCE`                    | Source Globus endpoint/collection                |
+| `AT_DESTINATION` | `--destination DESTINATION`          | Destination Globus endpoint/collection           |
+
+The `AT_SOURCE` and `AT_DESTINATION` are especially useful to point at your
+institutional storage systems.

--- a/USAGE.md
+++ b/USAGE.md
@@ -144,15 +144,7 @@ created by the `--size` option.
 Environment Variables
 ---------------------
 
-Several `archivetar` settings can be controlled by environment variables (handy
-for overriding defaults or for site-specific customization, e.g. inside Lmod
-modules).  Currently supported environment variables:
-
-| Variable         | Equivalent CLI option                | Meaning                                          |
-|------------------|--------------------------------------|--------------------------------------------------|
-| `AT_TAR_SIZE`    | `-t TAR_SIZE`, `--tar-size TAR_SIZE` | Target tar size before options (eg. `10G`, `1T`) |
-| `AT_SOURCE`      | `--source SOURCE`                    | Source Globus endpoint/collection                |
-| `AT_DESTINATION` | `--destination DESTINATION`          | Destination Globus endpoint/collection           |
-
-The `AT_SOURCE` and `AT_DESTINATION` are especially useful to point at your
-institutional storage systems.
+Several `archivetar` settings are controlled by environment variables (handy
+for setting or overriding defaults, or for site-specific customization, e.g.
+inside Lmod modules or personal shell starup files).  See the
+[configuration section of INSTALL.md](INSTALL.md#configuration) for details.

--- a/archivetar/archive_args.py
+++ b/archivetar/archive_args.py
@@ -94,7 +94,7 @@ def parse_args(args):
     parser.add_argument(
         "-t",
         "--tar-size",
-        help=f"Target tar size before options (eg. 10G 1T) Default: {tar_size}",
+        help=f"Target tar size before options (eg. 10G 1T). Can be set with AT_TAR_SIZE environment variable. Default: {tar_size}",
         type=str,
         default=tar_size,
     )
@@ -219,14 +219,14 @@ def parse_args(args):
     source_default = env.str("AT_SOURCE", default="umich#greatlakes")
     globus.add_argument(
         "--source",
-        help=f"Source endpoint/collection Default: {source_default}",
+        help=f"Source endpoint/collection. Can be set with AT_SOURCE environment variable. Default: {source_default}",
         default=source_default,
     )
 
     dest_default = env.str("AT_DESTINATION", default="umich#flux")
     globus.add_argument(
         "--destination",
-        help=f"Destination endpoint/collection Default: {dest_default}",
+        help=f"Destination endpoint/collection. Can be set with AT_DESTINATION environment variable. Default: {dest_default}",
         default=dest_default,
     )
     globus.add_argument(

--- a/archivetar/archive_args.py
+++ b/archivetar/archive_args.py
@@ -36,7 +36,7 @@ def stat_check(string):
     matched = re.match(r"^[+,-]?\d+$", string)
     if bool(matched):
         return string
-    raise ValueError("Intagers only, optionally prefixed with + or -")
+    raise ValueError("Integers only, optionally prefixed with + or -")
 
 
 def unix_check(string):
@@ -49,7 +49,7 @@ def unix_check(string):
     matched = re.match(r"^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$", string)
     if bool(matched):
         return string
-    raise ValueError("Intagers only, optionally prefixed with + or -")
+    raise ValueError("Integers only, optionally prefixed with + or -")
 
 
 def file_check(string):
@@ -71,14 +71,14 @@ def parse_args(args):
     )
     parser.add_argument(
         "--dryrun",
-        help="Print what would do but dont do it, aditional --dryrun increases how far the script runs\n 1 = Walk Filesystem and stop, 2 = Filter and create sublists",
+        help="Print what would do but don't do it, aditional --dryrun increases how far the script runs\n 1 = Walk Filesystem and stop, 2 = Filter and create sublists",
         action="count",
         default=0,
     )
     parser.add_argument(
         "-p",
         "--prefix",
-        help="prefix for tar eg prefix-1.tar prefix-2.tar etc",
+        help="prefix for tar, e.g. prefix-1.tar prefix-2.tar etc",
         type=str,
         required=True,
     )
@@ -142,7 +142,7 @@ def parse_args(args):
 
     filter_ops = parser.add_argument_group(
         title="Filtering Options",
-        description="Options to limit files included in the archive similar to options for unix find.  NOTICE: These should be used with care.  Improper mixing of filter and the --size option could result in unintended behavior if used without globus.",
+        description="Options to limit files included in the archive similar to options for unix find.  NOTICE: These should be used with care.  Improper mixing of filter and the --size option could result in unintended behavior if used without Globus.",
     )
     filter_ops.add_argument(
         "--atime",
@@ -190,7 +190,7 @@ def parse_args(args):
     )
     tar_opts.add_argument(
         "--ignore-failed-read",
-        help="Pass --ignore-failed-read to tar, Do not exit with nonzero on unreadable files or directories. .",
+        help="Pass --ignore-failed-read to tar, Do not exit with nonzero on unreadable files or directories.",
         action="store_true",
     )
 
@@ -244,7 +244,7 @@ def parse_args(args):
     )
     globus.add_argument(
         "--rm-at-files",
-        help="Remove archivetar created files (tar, index, tar-list) after globus transfer of tars",
+        help="Remove archivetar created files (tar, index, tar-list) after Globus transfer of tars",
         action="store_true",
     )
 


### PR DESCRIPTION
Mention relevant `AT_****` variables in [USAGE.md](USAGE.md) and in the `--help` output. 